### PR TITLE
Fix compatibility in remote version file (KSP 1.10.x)

### DIFF
--- a/GameData/000_AT_Utils/000_AT_Utils.version
+++ b/GameData/000_AT_Utils/000_AT_Utils.version
@@ -13,7 +13,7 @@
     "KSP_VERSION_MIN":
      {
          "MAJOR":1,
-         "MINOR":9,
+         "MINOR":10,
          "PATCH":0
      },
     "KSP_VERSION_MAX":


### PR DESCRIPTION
According to:

- KSP-CKAN/NetKAN#8085
- https://forum.kerbalspaceprogram.com/index.php?/topic/150104-19-110-configurable-containers/&do=findComment&comment=3830296

... the current release isn't compatible with KSP 1.9, but the version file says it is. This PR fixes that. Since the "URL" property of the version file in the download is set to:

- https://raw.githubusercontent.com/allista/AT_Utils/master/GameData/000_AT_Utils/000_AT_Utils.version

..., this will update the metadata for CKAN (within about 30 minutes).

I'll do one for ConfigurableContainers next (can't do both in one PR because they're in separate repos).